### PR TITLE
Disable weights only for generalist policy loading

### DIFF
--- a/compass/distillation/distillation.py
+++ b/compass/distillation/distillation.py
@@ -158,7 +158,7 @@ class ESDistillationPolicyWrapper(nn.Module):
     def __init__(self, distillation_policy_ckpt_path: str, embodiment_type: str):
         super().__init__()
         # Load the checkpoint and remove the prefix if any.
-        state_dict = torch.load(distillation_policy_ckpt_path)['state_dict']
+        state_dict = torch.load(distillation_policy_ckpt_path, weights_only=False)['state_dict']
         state_dict = {k.removeprefix('model.'): v for k, v in state_dict.items()}
         # Load the state dict.
         self.model = ESDistillationPolicy()


### PR DESCRIPTION
Issue: With different pytorch versions, weights_only is not default as False for ckpt loading, causing errors

Solution: Config weights_only as False for policy loading

Test: Tested locally with different torch versions